### PR TITLE
Reimplement logging

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -1,18 +1,38 @@
 
 server_start <- function(opts = server_opts()) {
   ports <- paste0(opts$interfaces, ":", opts$port %||% "0", collapse = ",")
+
+  if (!is.na(opts$access_log_file)) {
+    mkdirp(dirname(opts$access_log_file))
+    file.create(opts$access_log_file)
+  }
+  if (!is.na(opts$error_log_file)) {
+    mkdirp(dirname(opts$error_log_file))
+    file.create(opts$error_log_file)
+  }
+
   options <- c(
     "listening_ports"          = ports,
     "num_threads"              = opts$num_threads,
     "enable_keep_alive"        = c("no", "yes")[[opts$enable_keep_alive + 1]],
+    "access_log_file"          = opts$access_log_file %|NA|% "",
+    "error_log_file"           = opts$error_log_file %|NA|% "",
+
+    # These are not configurable currently
     "request_timeout_ms"       = "100000",
     "enable_auth_domain_check" = "no"
   )
-  .Call(c_server_start, options)
+
+  srv <- .Call(c_server_start, options)
+  attr(srv, "options") <- opts
+  srv
 }
 
 #' Presser web server options
 #'
+#' @param remote Meta-option. If set to `TRUE`, presser uses slightly
+#'   different defaults, that are more appropriate for a background
+#'   server process.
 #' @param port Port to start the web server on. Defaults to a randomly
 #'   chosen port.
 #' @param num_threads Number of request handler threads to use. Typically
@@ -23,11 +43,54 @@ server_start <- function(opts = server_opts()) {
 #'   interface if you know what you are doing. presser was not designed
 #'   to serve public web pages.
 #' @param enable_keep_alive Whether the server keeps connections alive.
+#' @param access_log_file `TRUE`, `FALSE`, or a path. See 'Logging'
+#'   below.
+#' @param error_log_file `TRUE`, `FALSE`, or a path. See 'Logging'
+#'   below.
+#'
+#' @section Logging:
+#'
+#' * For `access_log_file`, `TRUE` means `<log-dir>/access.log`.
+#' * For `error_log_file`, `TRUE` means `<log-dir>/error.log`.
+#'
+#' `<log-dir>` is set to the contents of the `PRESSER_LOG_DIR`
+#' environment variable, if it is set. Otherwise it is set to
+#' `<tmpdir>/presser` for local apps and `<tmpdir>/<pid>/presser` for
+#' remote apps (started with `new_app_procss()`).
+#'
+#' `<tmpdir>` is the session temporary directory of the _main process_.
+#'
+#' `<pid>` is the process id of the subprocess.
+#'
 #' @export
 
-server_opts <- function(port = NULL, num_threads = 1,
+server_opts <- function(remote = FALSE, port = NULL, num_threads = 1,
                         interfaces = "127.0.0.1",
-                        enable_keep_alive = TRUE) {
+                        enable_keep_alive = FALSE,
+                        access_log_file = remote,
+                        error_log_file = TRUE) {
+
+  log_dir <- Sys.getenv("PRESSER_LOG_DIR", file.path(tempdir(), "presser"))
+  if (isTRUE(access_log_file)) {
+    if (remote) {
+      access_log_file <- file.path(log_dir, "%p", "access.log")
+    } else {
+      access_log_file <- file.path(log_dir, "access.log")
+    }
+  } else if (isFALSE(access_log_file)) {
+    access_log_file <- NA_character_
+  }
+  if (isTRUE(error_log_file)) {
+    if (remote) {
+      error_log_file <- file.path(log_dir, "%p", "error.log")
+    } else {
+      error_log_file <- file.path(log_dir, "error.log")
+    }
+  } else if (isFALSE(error_log_file)) {
+    error_log_file <- NA_character_
+  }
+  rm(log_dir)
+
   as.list(environment())
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,8 @@
 
 `%||%` <- function(l, r) if (is.null(l)) r else l
 
+`%|NA|%` <- function(l, r) if (is_na_scalar(l)) r else l
+
 new_object <- function(class_name, ...) {
   structure(as.environment(list(...)), class = class_name)
 }
@@ -53,6 +55,12 @@ str_is_suffix <- function(x, sfx) {
   substring(x, lx - lsfx + 1, lx) == sfx
 }
 
+read_char <- function(path, encoding = "UTF-8") {
+  txt <- rawToChar(readBin(path, "raw", file.info(path)$size))
+  Encoding(txt) <- encoding
+  txt
+}
+
 read_bin <- function(path) {
   readBin(path, "raw", file.info(path)$size)
 }
@@ -83,4 +91,8 @@ set_envvar <- function(envs) {
   if (any(!set)) Sys.unsetenv(names(envs)[!set])
 
   invisible(old)
+}
+
+mkdirp <- function(path, ...) {
+  dir.create(path, showWarnings = FALSE, recursive = TRUE, ...)
 }

--- a/man/new_app.Rd
+++ b/man/new_app.Rd
@@ -242,15 +242,13 @@ response local variables (see \code{locals} in \link{presser_response}), are
 available.
 }
 
-\subsection{Starting and stopping}{\if{html}{\out{<div class="r">}}\preformatted{app$listen(port = NULL, num_threads = 1)
+\subsection{Starting and stopping}{\if{html}{\out{<div class="r">}}\preformatted{app$listen(port = NULL, opts = server_opts())
 }\if{html}{\out{</div>}}
 \itemize{
 \item \code{port}: port to listen on. When \code{NULL}, the operating system will
 automatically select a free port.
-\item \code{num_threads}: the number of threads that will handle HTTP
-requests. If you use asynchronous or parallel HTTP requests, then
-you probably want to increase this, to let the server handle
-multiple requests at the same time.
+\item \code{opts}: options to the web server. See \code{\link[=server_opts]{server_opts()}} for the
+list of options and their default values.
 }
 
 This method does not return, and can be interrupted with \code{CTRL+C} / \code{ESC}
@@ -268,6 +266,29 @@ the presser web app is never reachable from the network.\if{html}{\out{<div clas
   "presser_port" = function(msg) print(msg$port)
 )
 }\if{html}{\out{</div>}}
+}
+
+\subsection{Logging}{
+
+presser can write an access log that contains an entry for all incoming
+requests, and also an error log for the errors that happen while
+the server is running. This is the default behavior for local app
+(the ones started by \code{app$listen()} and for remote apps (the ones
+started via \code{new_app_process()}:
+\itemize{
+\item Local apps do not write an access log by default.
+\item Remote apps write an access log into the
+\verb{<tmpdir>/presser/<pid>/access.log} file, where \verb{<tmpdir>} is the
+session temporary directory of the \emph{main process}, and \verb{<pid>} is
+the process id of the \emph{subprocess}.
+\item Local apps write an error log to \verb{<tmpdir>/presser/error.log}, where
+\verb{<tmpdir>} is the session temporary directory of the current process.
+\item Remote app write an error log to the \verb{<tmpdir>/presser/<pid>/error.log},
+where \verb{<tmpdir>} is the session temporary directory of the
+\emph{main process} and \verb{<pid>} is the process id of the \emph{subprocess}`.
+}
+
+See \code{\link[=server_opts]{server_opts()}} for changing the default logging behavior.
 }
 
 \subsection{Shared app data}{\if{html}{\out{<div class="r">}}\preformatted{app$locals

--- a/man/new_app_process.Rd
+++ b/man/new_app_process.Rd
@@ -8,7 +8,7 @@
 new_app_process(
   app,
   port = NULL,
-  opts = server_opts(),
+  opts = server_opts(remote = TRUE),
   process_timeout = 5000,
   callr_opts = NULL
 )
@@ -47,7 +47,8 @@ url(path = "/", query = NULL)
 
 \code{get_port()} returns the port the web server is running on.
 
-\code{stop()} stops the web server, and also the subprocess.
+\code{stop()} stops the web server, and also the subprocess. If the error
+log file is not empty, then it dumps its contents to the screen.
 
 \code{get_state()} returns a string, the state of the web server:
 \itemize{

--- a/man/server_opts.Rd
+++ b/man/server_opts.Rd
@@ -5,13 +5,20 @@
 \title{Presser web server options}
 \usage{
 server_opts(
+  remote = FALSE,
   port = NULL,
   num_threads = 1,
   interfaces = "127.0.0.1",
-  enable_keep_alive = TRUE
+  enable_keep_alive = FALSE,
+  access_log_file = remote,
+  error_log_file = TRUE
 )
 }
 \arguments{
+\item{remote}{Meta-option. If set to \code{TRUE}, presser uses slightly
+different defaults, that are more appropriate for a background
+server process.}
+
 \item{port}{Port to start the web server on. Defaults to a randomly
 chosen port.}
 
@@ -25,7 +32,30 @@ interface if you know what you are doing. presser was not designed
 to serve public web pages.}
 
 \item{enable_keep_alive}{Whether the server keeps connections alive.}
+
+\item{access_log_file}{\code{TRUE}, \code{FALSE}, or a path. See 'Logging'
+below.}
+
+\item{error_log_file}{\code{TRUE}, \code{FALSE}, or a path. See 'Logging'
+below.}
 }
 \description{
 Presser web server options
 }
+\section{Logging}{
+
+\itemize{
+\item For \code{access_log_file}, \code{TRUE} means \verb{<log-dir>/access.log}.
+\item For \code{error_log_file}, \code{TRUE} means \verb{<log-dir>/error.log}.
+}
+
+\verb{<log-dir>} is set to the contents of the \code{PRESSER_LOG_DIR}
+environment variable, if it is set. Otherwise it is set to
+\verb{<tmpdir>/presser} for local apps and \verb{<tmpdir>/<pid>/presser} for
+remote apps (started with \code{new_app_procss()}).
+
+\verb{<tmpdir>} is the session temporary directory of the \emph{main process}.
+
+\verb{<pid>} is the process id of the subprocess.
+}
+

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,6 +1,0 @@
-
-read_char <- function(path, encoding = "UTF-8") {
-  txt <- rawToChar(readBin(path, "raw", file.info(path)$size))
-  Encoding(txt) <- encoding
-  txt
-}


### PR DESCRIPTION
* New server parameters `access_log_file` and
  `error_log_file`.
* Sensible default behavior, see docs.
* Notably, `app_process$stop()` dumps the error
  log to the screen, so we can see it in the testthat
  output.