### PR TITLE
Fix compilation and tests on Solaris

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -59,7 +59,7 @@
 #if defined(__linux__) && !defined(_XOPEN_SOURCE)
 #define _XOPEN_SOURCE 600 /* For flockfile() on Linux */
 #endif
-#if defined(__LSB_VERSION__)
+#if defined(__LSB_VERSION__) || defined(__sun)
 #define NEED_TIMEGM
 #define NO_THREAD_NAME
 #endif

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -22,9 +22,10 @@ teardown({ tmp$proc$stop(); unlink(tmp$tmp) })
 # that macOS has a png device.
 
 skip_without_png_device <- function() {
-  if (.Platform$OS.type == "windows" ||
-      Sys.info()["sysname"] == "Darwin") return()
-  if (! capabilities()[["png"]]) skip("Needs a PNG device")
+  if (.Platform$OS.type == "windows") return()
+  if (! capabilities("png") || ! capabilities("X11")) {
+    skip("Needs a PNG device")
+  }
 }
 
 test_that("presser_app", {


### PR DESCRIPTION
1. Need a small civetweb fix to compile.
2. Need to work around the `testthat::verify_output()` & `png()` issue.