### PR TITLE
Update how-to.Rmd

### DIFF
--- a/vignettes/how-to.Rmd
+++ b/vignettes/how-to.Rmd
@@ -133,7 +133,7 @@ Sys.unsetenv("GITHUB_API")
 
 ```{r}
 http <- presser::local_app_process(presser::httpbin_app(), start = TRUE)
-http$local_env(list(GITHUB_API = http$url()))
+http$local_env(list(GITHUB_API = "{url}"))
 Sys.getenv("GITHUB_API")
 http$stop()
 Sys.getenv("GITHUB_API")


### PR DESCRIPTION
As it seems it'll work even in cases where the app isn't started yet?

Should `{url}` be documented more, what other such shortcuts are there?